### PR TITLE
Fix email confirmation flow and add local mail viewer

### DIFF
--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,37 @@
 from django.test import TestCase
+from django.core import mail
+from django.urls import reverse
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 
-# Create your tests here.
+from authentication.models import User
+from authentication.tokens import account_activation_token
+
+
+class EmailConfirmationTests(TestCase):
+    def test_register_sends_activation_email(self):
+        response = self.client.post(reverse('register'), {
+            'email': 'newuser@example.com',
+            'timezone': 'US/Eastern',
+            'password1': 'mostdope1',
+            'password2': 'mostdope1',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn('newuser@example.com', mail.outbox[0].to)
+
+    def test_activation_link_confirms_email_and_logs_in(self):
+        user = User.objects.create_user(
+            email='pending@example.com', password='mostdope1')
+        self.assertFalse(user.confirmed_email)
+
+        url = reverse('activate', kwargs={
+            'uidb64': urlsafe_base64_encode(force_bytes(user.pk)),
+            'token': account_activation_token.make_token(user),
+        })
+        response = self.client.get(url)
+
+        user.refresh_from_db()
+        self.assertTrue(user.confirmed_email)
+        self.assertRedirects(response, reverse('index'))

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from . import views
 
@@ -13,8 +13,5 @@ urlpatterns = [
          name='resend_confirmation'),
     path('unconfirmed_email/', views.unconfirmed_email,
          name='unconfirmed_email'),
-    re_path(
-        r'^activate/(?P<uidb64>[0-9A-Za-z_\-]+)/'
-        r'(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-        views.activate, name='activate'),
+    path('activate/<uidb64>/<token>/', views.activate, name='activate'),
 ]

--- a/dailyinquirer/settings/local.py
+++ b/dailyinquirer/settings/local.py
@@ -5,4 +5,8 @@ DEBUG = True
 # Database
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+# Sent emails are captured in memory and browsable at /mailbox/.
+# Requires the dev dependency: pip install -r requirements-dev.txt
+INSTALLED_APPS.append('django_mail_viewer')
+
+EMAIL_BACKEND = 'django_mail_viewer.backends.locmem.EmailBackend'

--- a/dailyinquirer/urls.py
+++ b/dailyinquirer/urls.py
@@ -1,4 +1,5 @@
 """dailyinquirer URL Configuration."""
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.views import LogoutView
 from django.urls import include, path
@@ -9,3 +10,7 @@ urlpatterns = [
     path('', include('core.urls')),
     path('', include('django.contrib.auth.urls')),
 ]
+
+# Local-only email inbox UI; the app is installed only in dev settings.
+if 'django_mail_viewer' in settings.INSTALLED_APPS:
+    urlpatterns += [path('mailbox/', include('django_mail_viewer.urls'))]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Development-only dependencies. Production installs requirements.txt only.
+-r requirements.txt
+
+django-mail-viewer~=2.2


### PR DESCRIPTION
## Summary

Email confirmation was already implemented but broken by the Django 1.11 → 5.2 upgrade. This branch fixes it and adds a local tool for inspecting the emails it sends.

### Fix the broken activation link
The `activate` URL hard-coded a 20-character cap on the token hash — correct for Django 1.11's sha1 tokens, but Django 5.2's sha256 tokens are 32 characters. After the upgrade, `{% url 'activate' %}` could no longer reverse the link and **every signup raised `NoReverseMatch` (500)**.

Replaced the hand-rolled regex with `path()` converters, matching Django's own `password_reset_confirm` URL. Token validity is still enforced by `account_activation_token.check_token()` in the `activate` view, so the URL never needed to constrain token shape — and this won't break again if a future Django changes its hash algorithm.

Added tests covering activation email delivery and link confirmation (`core/tests.py` was previously empty).

### Add django-mail-viewer for local dev
Sent emails now land in an in-memory inbox browsable at `/mailbox/` instead of being echoed to the server log. Installed only in local settings; the `/mailbox/` route registers only when the app is present, so **production is unaffected**. The package is a dev-only dependency in a new `requirements-dev.txt` — the production Dockerfile still installs `requirements.txt` alone.

## Testing
- `python manage.py test` — 4 tests pass
- Verified end-to-end against the dev server: registration returns 200 (no crash), the activation email appears in `/mailbox/`, and the activation link confirms the account

🤖 Generated with [Claude Code](https://claude.com/claude-code)