### PR TITLE
Add CI workflow to test on PRs and deploy on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: python manage.py test
+
+  deploy:
+    needs: test
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` with two jobs
- `test`: runs `python manage.py test` (Python 3.14, SQLite via `local` settings) on every PR and every push to `main`
- `deploy`: runs `flyctl deploy --remote-only` on `main` pushes only, gated behind `needs: test`; a `concurrency` group prevents racing deploys

## Setup required
Add a `FLY_API_TOKEN` repo secret (generate with `fly tokens create deploy`) under Settings → Secrets and variables → Actions. Until then, `test` still runs on PRs; only `deploy` would fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)