### PR TITLE
Fix /logout returning 405 Method Not Allowed

### DIFF
--- a/core/templates/core/settings.html
+++ b/core/templates/core/settings.html
@@ -51,7 +51,10 @@
             </div>
             <input type="submit" class="btn btn-light btn-block mb-2" value="Reset password" />
         </form>
-        <a href="/logout/" class="btn btn-light btn-block mb-2">Logout</a>
+        <form action="/logout/" method="post">
+            {% csrf_token %}
+            <input type="submit" class="btn btn-light btn-block mb-2" value="Logout" />
+        </form>
     </div>
 </div>
 

--- a/core/tests.py
+++ b/core/tests.py
@@ -71,6 +71,40 @@ class HomePageTests(TestCase):
         self.assertContains(response, 'href="/login/"')
 
 
+class LogoutTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='member@example.com', password='mostdope1')
+        self.user.confirmed_email = True
+        self.user.save()
+
+    def test_settings_page_logout_control_uses_post(self):
+        """The settings page must log out via POST, not a GET link.
+
+        Django's LogoutView only accepts POST; a bare <a href="/logout/">
+        issues a GET and the server responds 405 Method Not Allowed.
+        """
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('settings'))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, '<a href="/logout/"')
+        self.assertContains(response, 'action="/logout/"')
+
+    def test_get_logout_is_rejected(self):
+        """A GET to /logout/ is the exact failure from the bug report."""
+        self.client.force_login(self.user)
+        response = self.client.get(reverse('logout'))
+        self.assertEqual(response.status_code, 405)
+
+    def test_post_logout_logs_user_out_and_redirects_home(self):
+        self.client.force_login(self.user)
+        response = self.client.post(reverse('logout'))
+        self.assertRedirects(response, '/')
+        # The user is anonymous on the next request.
+        followup = self.client.get(reverse('settings'))
+        self.assertNotEqual(followup.status_code, 200)
+
+
 class AuthPagesTests(TestCase):
     def _assert_editorial_shell(self, response):
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Problem

Visiting `/logout/` returned **405 Method Not Allowed**. Django 5.x's `LogoutView` only accepts POST (GET logout was removed in Django 5.0), but `core/templates/core/settings.html` rendered the Logout control as a plain `<a href="/logout/">` anchor — clicking it issued a GET.

## Fix

- Replace the logout anchor with a CSRF-protected POST `<form>`. This is Django's recommended approach and prevents logout-via-CSRF.
- Add `LogoutTests` covering the regression: the settings page uses a POST control, GET `/logout/` is rejected with 405, and POST `/logout/` logs the user out and redirects home.

All 21 core tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)