### PR TITLE
Fix repair_migration_history: heal the broken migration ledger

### DIFF
--- a/core/management/commands/repair_migration_history.py
+++ b/core/management/commands/repair_migration_history.py
@@ -1,46 +1,64 @@
-"""One-time repair for an inconsistent production migration history.
+"""Repair an inconsistent migration history before ``migrate`` runs.
 
 Background
 ----------
-PR #24 added ``core.0007_seed_thirty_days_of_prompts`` depending on
-``core.0006_entry_...``; it deployed and was recorded as applied on
-production. PR #25 then resolved a migration-graph conflict by creating
-the no-op merge migration ``core.0007_merge_20260517_2159`` and
-re-pointing the (already-applied) seed migration's dependency onto it.
+PRs #23 and #24 each added a ``core`` migration on parallel branches:
+``0005_promptsend`` (the ``PromptSend`` model) and the data migration
+``0007_seed_thirty_days_of_prompts``. PR #25 resolved the resulting
+migration-graph conflict with the no-op merge migration
+``0007_merge_20260517_2159`` and re-pointed the seed migration onto it.
 
-The result: production's ``django_migrations`` table has the seed
-migration recorded as applied while its new dependency, the merge
-migration, is missing. ``manage.py migrate`` runs
-``check_consistent_history`` before doing anything and aborts with
-``InconsistentMigrationHistory`` -- which crashes the container on boot.
+A database that applied the seed migration *before* PR #25 reshaped the
+graph -- production did -- ends up with ``0007_seed`` recorded as applied
+while its dependency ``0005_promptsend`` never ran. ``manage.py migrate``
+runs ``check_consistent_history`` first and aborts with
+``InconsistentMigrationHistory``, which crash-loops the container.
 
-``migrate --fake`` cannot fix this: it runs the same consistency check
-first. The fix has to write the missing ledger row directly, which is
-what this command does. It is invoked from ``start.sh`` before
-``migrate`` and is safe to keep -- it is a precise, idempotent no-op
-once the history is consistent (and on any fresh database).
+(An earlier version of this command tried to patch that by *recording*
+the merge migration as applied. That only deepened the hole -- it left
+the merge applied while ``0005_promptsend`` was still missing, i.e. the
+exact ``0007_merge ... applied before ... 0005_promptsend`` crash.)
+
+Fix
+---
+Roll the ledger back to ``0006`` by un-recording any 0007 migration that
+was applied ahead of ``0005_promptsend``. The ``migrate`` step that
+follows in ``start.sh`` then re-applies ``0005_promptsend`` (creating the
+missing ``PromptSend`` table), the merge, and the seed in dependency
+order. The seed migration skips dates that already have a prompt, so
+re-running it creates no duplicates.
+
+Invoked from ``start.sh`` before ``migrate``; a safe, idempotent no-op
+once the history is consistent (and on a fresh database).
 """
 
 from django.core.management.base import BaseCommand
 from django.db import connection
 from django.db.migrations.recorder import MigrationRecorder
 
-SEED = ("core", "0007_seed_thirty_days_of_prompts")
+PROMPTSEND = ("core", "0005_promptsend")
 MERGE = ("core", "0007_merge_20260517_2159")
+SEED = ("core", "0007_seed_thirty_days_of_prompts")
 
 
 class Command(BaseCommand):
-    help = "Record the 0007 merge migration if its dependent was applied without it."
+    help = "Roll back 0007 migrations applied before their 0005_promptsend dependency."
 
     def handle(self, *args, **options):
         recorder = MigrationRecorder(connection)
         applied = recorder.applied_migrations()
 
-        if SEED in applied and MERGE not in applied:
-            recorder.record_applied(*MERGE)
+        # Inconsistent: a 0007 migration is recorded as applied while its
+        # dependency 0005_promptsend is not. Un-record the 0007 nodes so
+        # the migrate step that follows re-applies the whole trio in order.
+        ahead = [m for m in (MERGE, SEED) if m in applied]
+        if PROMPTSEND not in applied and ahead:
+            for app, name in ahead:
+                recorder.record_unapplied(app, name)
+            names = ", ".join(name for _, name in ahead)
             self.stdout.write(
-                f"repair: recorded {MERGE[0]}.{MERGE[1]} as applied "
-                f"(dependent {SEED[1]} was applied without it)"
+                f"repair: un-recorded {names} (applied before dependency "
+                f"core.0005_promptsend); migrate will re-apply in order"
             )
         else:
             self.stdout.write("repair: migration history consistent, nothing to do")


### PR DESCRIPTION
## Why

Production is **crash-looping on boot**:

```
django.db.migrations.exceptions.InconsistentMigrationHistory:
Migration core.0007_merge_20260517_2159 is applied before its
dependency core.0005_promptsend on database 'default'.
```

`start.sh` runs `repair_migration_history` then `migrate`; the `migrate`
consistency check aborts, the container exits 1, Fly restarts it — forever.

## Root cause

The old `repair_migration_history` recorded the `0007` **merge** migration as
applied whenever the **seed** was applied without it — but never checked that
the merge's *own* dependency, `0005_promptsend`, was applied.

Production applied the seed migration before PR #25 reshaped the migration
graph, so `0005_promptsend` never ran there. The old command then recorded the
merge on top of that gap — manufacturing the exact inconsistency that now
crash-loops the box.

## Fix

Roll the ledger **back** to `0006`: un-record any `0007` migration found applied
ahead of `0005_promptsend`. The `migrate` step that follows in `start.sh` then
re-applies `0005_promptsend` (creating the missing `PromptSend` table), the
merge, and the seed in dependency order. `0007_seed` skips dates that already
have a prompt, so re-running it creates **no duplicates**.

Idempotent no-op once the history is consistent, and on a fresh database.

## Verification

Reproduced production's exact broken state on a local DB (dropped
`core_promptsend`, un-recorded `0005_promptsend`):

- `migrate` alone → reproduced the identical `InconsistentMigrationHistory` crash
- `repair_migration_history` → un-recorded the two `0007` nodes
- `migrate` → applied `0005_promptsend`, `0007_merge`, `0007_seed` cleanly
- End state: `core_promptsend` table exists, **30 prompts (no dupes)**, ledger consistent
- Re-running repair + migrate → clean no-ops
- `python manage.py test` → **76 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)