### PR TITLE
Repair migration ledger when 0007 tip applied without 0005_promptsend

### DIFF
--- a/core/management/commands/repair_migration_history.py
+++ b/core/management/commands/repair_migration_history.py
@@ -1,46 +1,57 @@
-"""One-time repair for an inconsistent production migration history.
+"""Repair an inconsistent production migration history before ``migrate``.
 
 Background
 ----------
-PR #24 added ``core.0007_seed_thirty_days_of_prompts`` depending on
-``core.0006_entry_...``; it deployed and was recorded as applied on
-production. PR #25 then resolved a migration-graph conflict by creating
-the no-op merge migration ``core.0007_merge_20260517_2159`` and
-re-pointing the (already-applied) seed migration's dependency onto it.
+PR #24 added ``core.0007_seed_thirty_days_of_prompts``; PR #23/#25 then
+introduced ``core.0005_promptsend`` and the no-op merge migration
+``core.0007_merge_20260517_2159``, and re-pointed the seed migration's
+dependency onto the merge.
 
-The result: production's ``django_migrations`` table has the seed
-migration recorded as applied while its new dependency, the merge
-migration, is missing. ``manage.py migrate`` runs
-``check_consistent_history`` before doing anything and aborts with
-``InconsistentMigrationHistory`` -- which crashes the container on boot.
+On production the 0007 tip -- the merge and/or seed migrations -- ended
+up recorded as applied in ``django_migrations`` while the merge's
+dependency ``core.0005_promptsend`` never was. ``manage.py migrate``
+runs ``check_consistent_history`` before doing anything and aborts with
+``InconsistentMigrationHistory`` -- crashing the container on boot.
+``migrate --fake`` cannot help: it runs the same check first.
 
-``migrate --fake`` cannot fix this: it runs the same consistency check
-first. The fix has to write the missing ledger row directly, which is
-what this command does. It is invoked from ``start.sh`` before
-``migrate`` and is safe to keep -- it is a precise, idempotent no-op
-once the history is consistent (and on any fresh database).
+This command removes the orphaned 0007 ledger rows so ``migrate`` can
+replay ``0005_promptsend -> 0007_merge -> 0007_seed`` forward, creating
+the missing ``core_promptsend`` table. The seed migration only inserts
+prompts for dates that have none, so replaying it is safe.
+
+It runs from ``start.sh`` before ``migrate`` and is a precise,
+idempotent no-op once history is consistent (and on any fresh database).
 """
 
 from django.core.management.base import BaseCommand
 from django.db import connection
 from django.db.migrations.recorder import MigrationRecorder
 
-SEED = ("core", "0007_seed_thirty_days_of_prompts")
-MERGE = ("core", "0007_merge_20260517_2159")
+PROMPTSEND = ("core", "0005_promptsend")
+# The 0007 tip that depends (transitively) on 0005_promptsend. Order does
+# not matter -- un-recording is a row delete -- but the merge must go too:
+# leaving the seed without the merge would just shift the inconsistency.
+TIP = [
+    ("core", "0007_merge_20260517_2159"),
+    ("core", "0007_seed_thirty_days_of_prompts"),
+]
 
 
 class Command(BaseCommand):
-    help = "Record the 0007 merge migration if its dependent was applied without it."
+    help = "Un-record the 0007 tip if it was applied without 0005_promptsend."
 
     def handle(self, *args, **options):
         recorder = MigrationRecorder(connection)
         applied = recorder.applied_migrations()
 
-        if SEED in applied and MERGE not in applied:
-            recorder.record_applied(*MERGE)
-            self.stdout.write(
-                f"repair: recorded {MERGE[0]}.{MERGE[1]} as applied "
-                f"(dependent {SEED[1]} was applied without it)"
-            )
+        orphaned = [m for m in TIP if m in applied]
+        if PROMPTSEND not in applied and orphaned:
+            for migration in orphaned:
+                recorder.record_unapplied(*migration)
+                self.stdout.write(
+                    f"repair: un-recorded {migration[0]}.{migration[1]} "
+                    f"(applied without dependency {PROMPTSEND[1]})"
+                )
         else:
-            self.stdout.write("repair: migration history consistent, nothing to do")
+            self.stdout.write(
+                "repair: migration history consistent, nothing to do")

--- a/core/tests.py
+++ b/core/tests.py
@@ -3,7 +3,8 @@ from datetime import datetime
 from unittest.mock import patch
 
 from django.core.management import call_command
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, connection, transaction
+from django.db.migrations.recorder import MigrationRecorder
 from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.core import mail
@@ -681,3 +682,40 @@ class EntryContentUnwrapTests(TestCase):
         self.assertContains(response, '<p>The night was bright. The town slept.</p>')
         self.assertContains(response, '<p>Then dawn came.</p>')
         self.assertNotContains(response, 'bright.<br>')
+
+
+class RepairMigrationHistoryTests(TestCase):
+    """`repair_migration_history` un-records an orphaned 0007 tip.
+
+    Production once had core.0007_merge / 0007_seed recorded as applied
+    while their dependency core.0005_promptsend never was, so `migrate`'s
+    consistency check crashed the container on boot. The command removes
+    the orphaned ledger rows so `migrate` can replay the chain forward.
+    """
+
+    PROMPTSEND = ("core", "0005_promptsend")
+    MERGE = ("core", "0007_merge_20260517_2159")
+    SEED = ("core", "0007_seed_thirty_days_of_prompts")
+
+    def test_un_records_0007_tip_applied_without_promptsend(self):
+        recorder = MigrationRecorder(connection)
+        # Simulate the broken production ledger: the 0007 tip is recorded
+        # as applied, but its dependency 0005_promptsend never was.
+        recorder.record_unapplied(*self.PROMPTSEND)
+        applied = recorder.applied_migrations()
+        self.assertIn(self.MERGE, applied)
+        self.assertIn(self.SEED, applied)
+
+        call_command("repair_migration_history")
+
+        applied = recorder.applied_migrations()
+        self.assertNotIn(self.MERGE, applied)
+        self.assertNotIn(self.SEED, applied)
+
+    def test_no_op_when_history_is_consistent(self):
+        recorder = MigrationRecorder(connection)
+        before = set(recorder.applied_migrations())
+
+        call_command("repair_migration_history")
+
+        self.assertEqual(set(recorder.applied_migrations()), before)


### PR DESCRIPTION
## Problem

Production was crash-looping on boot:

```
django.db.migrations.exceptions.InconsistentMigrationHistory: Migration core.0007_merge_20260517_2159 is applied before its dependency core.0005_promptsend on database 'default'.
```

Production's `django_migrations` ledger had `core.0007_merge_20260517_2159` and `0007_seed_thirty_days_of_prompts` recorded as applied, but the merge's dependency `core.0005_promptsend` was never applied — so the `core_promptsend` table doesn't exist. `migrate`'s `check_consistent_history` aborts before doing anything.

The existing `repair_migration_history` only handled the *other* inconsistency (seed applied without merge). It recorded the merge in an earlier boot, which just moved the inconsistency one link down the chain to `0005_promptsend` — which it couldn't fix.

## Fix

Rewrite the command to **un-record** the orphaned 0007 tip (`0007_merge` + `0007_seed`) when `0005_promptsend` is missing. That makes the ledger consistent, so the following `migrate` replays `0005_promptsend → 0007_merge → 0007_seed` forward, creating the missing table. The seed migration is idempotent (skips dates that already have a prompt), so the replay is safe. Stays an idempotent no-op once history is consistent and on fresh databases.

`start.sh` already runs `repair_migration_history` before `migrate`, so the next deploy self-heals.

## Verification

- New `RepairMigrationHistoryTests` in `core/tests.py`, written test-first. Full suite: 78 tests OK.
- End-to-end against a SQLite DB reproducing the exact broken ledger: `migrate` failed with the identical error → `repair_migration_history` un-recorded the tip → `migrate` cleanly applied `0005_promptsend`/`0007_merge`/`0007_seed`, `core_promptsend` created, 30 prompts seeded, re-running repair is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)