### PR TITLE
Allow overriding the dev server port with a -p flag

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -17,8 +17,23 @@ $PYTHON manage.py repair_migration_history
 $PYTHON manage.py migrate --noinput
 
 # Pass "dev" to run the Django development server (uses settings.local).
+# An optional "-p <port>" overrides the default port 8000.
 if [ "$1" = "dev" ]; then
-    exec $PYTHON manage.py runserver 0.0.0.0:8000
+    PORT=8000
+    shift
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -p)
+                PORT="$2"
+                shift 2
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                exit 1
+                ;;
+        esac
+    done
+    exec $PYTHON manage.py runserver "0.0.0.0:$PORT"
 fi
 
 # Run the hourly prompt cron alongside the web server (production only — the


### PR DESCRIPTION
## Summary

`./start.sh dev` now accepts an optional `-p <port>` flag to override the default port 8000.

- `./start.sh dev` — runs on `0.0.0.0:8000` as before
- `./start.sh dev -p 9000` — runs on `0.0.0.0:9000`

Unknown flags after `dev` exit with an error.

## Test plan

- [ ] `./start.sh dev` still serves on port 8000
- [ ] `./start.sh dev -p 9000` serves on port 9000
- [ ] `./start.sh dev -x` exits with "Unknown option" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)