### PR TITLE
Replace onboarding opt-in checkbox with two choice cards

### DIFF
--- a/core/templates/core/onboarding.html
+++ b/core/templates/core/onboarding.html
@@ -26,10 +26,21 @@
     <form method="post" action="" id="onboarding-form">
       {% csrf_token %}
       <div class="ed-field">
-        <label class="ed-check">
-          <input type="checkbox" name="subscribed">
-          <span>Email me a writing prompt every day.</span>
-        </label>
+        <span class="ed-field__label">Daily email</span>
+        <div class="ed-optgroup">
+          <label class="ed-optopt">
+            <input type="radio" name="subscribed" value="false" checked>
+            <span class="ed-optopt__emoji">📖</span>
+            <span class="ed-optopt__name">Not right now</span>
+            <span class="ed-optopt__desc">Just browse the site</span>
+          </label>
+          <label class="ed-optopt">
+            <input type="radio" name="subscribed" value="true">
+            <span class="ed-optopt__emoji">✉️</span>
+            <span class="ed-optopt__name">Email me daily</span>
+            <span class="ed-optopt__desc">A prompt each morning</span>
+          </label>
+        </div>
         <p class="ed-hint">You can change this any time in settings.</p>
       </div>
       <div class="ed-field">

--- a/core/tests.py
+++ b/core/tests.py
@@ -1005,6 +1005,29 @@ class OnboardingPageTests(TestCase):
         self.assertTrue(self.user.onboarded)
         self.assertFalse(self.user.is_subscribed)
 
+    def test_post_with_subscribed_false_opts_the_user_out(self):
+        # The "Not right now" choice card submits subscribed=false.
+        self.client.post(reverse('onboarding'), {
+            'subscribed': 'false', 'timezone': 'UTC', 'mail_hour': '8'})
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.onboarded)
+        self.assertFalse(self.user.is_subscribed)
+
+    def test_post_with_subscribed_true_opts_the_user_in(self):
+        # The "Email me daily" choice card submits subscribed=true.
+        self.client.post(reverse('onboarding'), {
+            'subscribed': 'true', 'timezone': 'UTC', 'mail_hour': '8'})
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_subscribed)
+
+    def test_page_offers_the_optin_choice_cards(self):
+        response = self.client.get(reverse('onboarding'))
+        self.assertContains(response, 'Not right now')
+        self.assertContains(response, 'Email me daily')
+        # "Not right now" is the default selection.
+        self.assertContains(
+            response, '<input type="radio" name="subscribed" value="false" checked>')
+
     def test_already_onboarded_user_is_redirected_to_dashboard(self):
         self.user.onboarded = True
         self.user.save()

--- a/dailyinquirer/static/css/account.css
+++ b/dailyinquirer/static/css/account.css
@@ -269,6 +269,67 @@
   margin: 4px 0 16px;
 }
 
+/* --- Onboarding: daily-email opt-in choice cards ------------ */
+
+#onboarding .ed-optgroup {
+  display: flex;
+  gap: 8px;
+}
+
+#onboarding .ed-optopt {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 14px 8px;
+  background: #fff;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  cursor: pointer;
+  text-align: center;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+#onboarding .ed-optopt:hover {
+  border-color: var(--accent);
+}
+
+#onboarding .ed-optopt:has(input:focus-visible) {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+#onboarding .ed-optopt:has(input:checked) {
+  border-color: var(--accent);
+  background: rgba(var(--accent-rgb), 0.06);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+#onboarding .ed-optopt input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+#onboarding .ed-optopt__emoji {
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+#onboarding .ed-optopt__name {
+  font-family: var(--body);
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--ink);
+}
+
+#onboarding .ed-optopt__desc {
+  font-family: var(--body);
+  font-size: 0.875rem;
+  color: var(--ink-faint);
+}
+
 /* --- Onboarding: Morning / Day / Night time picker ---------- */
 
 #onboarding .ed-timegroup {


### PR DESCRIPTION
## What

The subscribe checkbox on the onboarding page was too subtle to register as a real decision. This replaces it with two selectable choice cards:

- **Not right now** — Just browse the site
- **Email me daily** — A prompt each morning

The cards reuse the visual language of the existing Morning/Day/Night delivery-time picker, so the opt-in reads as a deliberate choice. "Not right now" is selected by default, matching the current unsubscribed-by-default behavior.

## How

- Native `<input type="radio" name="subscribed">` elements — no JavaScript. The radios are hidden via CSS and the `<label>` cards toggle them; the selected state uses `:has(input:checked)`.
- The form field stays `name="subscribed"`, so `OnboardingForm` and the view are unchanged — Django's `BooleanField`/`CheckboxInput` cleaning maps `"true"`→True, `"false"`→False.
- Everything else on the page is untouched: time zone field, delivery-time presets and manual hour dropdown, all hints, and the Finish setup / Log out buttons.

## Tests

Added 3 tests covering the values the cards submit (`subscribed=true`/`false`) and the cards rendering with "Not right now" pre-selected. Full suite passes (137 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)