### PR TITLE
Show in-page success for signed-in password reset

### DIFF
--- a/core/templates/core/settings.html
+++ b/core/templates/core/settings.html
@@ -114,9 +114,8 @@
     </div>
 
     <div class="ed-actions">
-      <form action="/password_reset/" method="post">
+      <form action="{% url 'send_password_reset' %}" method="post">
         {% csrf_token %}
-        <input type="hidden" name="email" value="{{ user.email }}">
         <button class="ed-btn-ghost" type="submit">Reset password</button>
       </form>
       <form action="/logout/" method="post">
@@ -124,6 +123,9 @@
         <button class="ed-btn-ghost" type="submit">Log out</button>
       </form>
     </div>
+    {% if password_reset_sent %}
+    <div class="ed-alert ed-alert--ok">Password reset link sent to {{ user.email }}.</div>
+    {% endif %}
     <p class="ed-hint">Reset password sends a link to {{ user.email }}.</p>
   </section>
 </div>

--- a/core/tests.py
+++ b/core/tests.py
@@ -659,6 +659,18 @@ class SettingsPageTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'ed-alert--ok')
 
+    def test_password_reset_sends_email_and_stays_on_settings(self):
+        response = self.client.post(reverse('send_password_reset'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="settings"')
+        self.assertContains(response, 'Password reset link sent')
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn(self.user.email, mail.outbox[0].to)
+
+    def test_password_reset_rejects_get(self):
+        response = self.client.get(reverse('send_password_reset'))
+        self.assertEqual(response.status_code, 405)
+
 
 class DashboardTests(TestCase):
     def setUp(self):

--- a/core/urls.py
+++ b/core/urls.py
@@ -24,6 +24,8 @@ urlpatterns = [
     path('activate/<uidb64>/<token>/', views.activate, name='activate'),
     path('settings/email/', views.manage_email_change,
          name='manage_email_change'),
+    path('settings/password/', views.send_password_reset,
+         name='send_password_reset'),
     path('settings/email/confirm/<uidb64>/<token>/',
          views.confirm_email_change, name='confirm_email_change'),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -9,6 +9,7 @@ from django.utils.encoding import force_str
 from django.utils.http import urlsafe_base64_decode
 from authentication.tokens import account_activation_token, email_change_token
 from django.contrib.auth import login, logout
+from django.contrib.auth.forms import PasswordResetForm
 from django.contrib import messages
 from django.views.decorators.csrf import csrf_exempt
 from django.utils import timezone
@@ -198,6 +199,26 @@ def settings(request):
                 "We couldn't complete the email change — that address "
                 "is no longer available.")
 
+    return render(request, 'core/settings.html', context)
+
+
+@login_required
+def send_password_reset(request):
+    """Email a password-reset link to the signed-in user without leaving
+    the settings page."""
+    if request.method != 'POST':
+        return HttpResponseNotAllowed(['POST'])
+    form = PasswordResetForm({'email': request.user.email})
+    if form.is_valid():
+        form.save(
+            request=request,
+            use_https=request.is_secure(),
+            email_template_name='email/password_reset.txt',
+            html_email_template_name='email/password_reset.html',
+            subject_template_name='email/password_reset_subject.txt',
+        )
+    context = {'timezones': pytz.common_timezones, 'hours': HOUR_CHOICES,
+               'password_reset_sent': True}
     return render(request, 'core/settings.html', context)
 
 

--- a/dailyinquirer/static/css/account.css
+++ b/dailyinquirer/static/css/account.css
@@ -232,6 +232,10 @@
   margin: 0;
 }
 
+.app .ed-actions + .ed-alert {
+  margin-top: 14px;
+}
+
 /* --- Alert -------------------------------------------------- */
 
 .app .ed-alert {


### PR DESCRIPTION
## Summary

The signed-in "Reset password" button on the Settings page used to POST to Django's `PasswordResetView`, which redirects to a standalone `password_reset_done` page. Now it sends the email and stays on Settings, showing a success box under the buttons.

- Added `send_password_reset` — a `@login_required`, POST-only view that emails the reset link via `PasswordResetForm` (reusing the existing email templates) and re-renders `settings.html` with a `password_reset_sent` flag.
- Added the `settings/password/` route (`send_password_reset`).
- Updated `settings.html` to point the form at the new route, drop the now-unneeded hidden email field, and render a `Password reset link sent to <email>` alert beneath the buttons.
- Added `margin-top` to the alert when it follows the action buttons so it isn't flush against them.

The public, logged-out password reset flow is untouched.

## Test plan

- `python manage.py test` — all 176 tests pass.
- New `SettingsPageTests` cases: email is sent and the page stays on Settings; GET is rejected (405).

🤖 Generated with [Claude Code](https://claude.com/claude-code)