### PR TITLE
Add Log in link to duplicate-email signup error

### DIFF
--- a/dailyinquirer/static/css/auth.css
+++ b/dailyinquirer/static/css/auth.css
@@ -288,6 +288,15 @@
   margin-top: 4px;
 }
 
+.auth-page .auth-error .auth-link {
+  color: var(--danger);
+  font-weight: 700;
+}
+
+.auth-page .auth-error .auth-link:hover {
+  color: var(--danger);
+}
+
 /* --- Responsive -------------------------------------------- */
 
 /* Narrow screens: tighten card padding */

--- a/templates/registration/_form_errors.html
+++ b/templates/registration/_form_errors.html
@@ -1,7 +1,7 @@
 {% if form.errors %}
 <div class="auth-error" role="alert">
   {% for field in form %}{% for error in field.errors %}
-  <p>{{ error|escape }}</p>
+  <p>{{ error|escape }}{% if "already exists" in error %} <a href="{% url 'login' %}" class="auth-link">Log in</a>{% endif %}</p>
   {% endfor %}{% endfor %}
   {% for error in form.non_field_errors %}
   <p>{{ error|escape }}</p>


### PR DESCRIPTION
## Summary

When signing up with an email that already exists, the error message ("User with this Email address already exists.") now includes a **Log in** link right beside it so users can jump straight to logging in.

- `_form_errors.html`: appends a `Log in` link to any field error containing "already exists" (only the registration form's unique-email check produces this; the shared partial's other consumers — login, password reset, resend confirmation — are unaffected).
- `auth.css`: styles the link inside `.auth-error` as bold and red to match the error text, including the hover state.

## Test plan

- Submit the signup form with an already-registered email and confirm the bold red "Log in" link appears next to the error and navigates to the login page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)