### PR TITLE
Use squared picker for settings subscribe toggle and reorder sections

### DIFF
--- a/core/templates/core/onboarding.html
+++ b/core/templates/core/onboarding.html
@@ -30,15 +30,15 @@
         <div class="ed-optgroup">
           <label class="ed-optopt">
             <input type="radio" name="subscribed" value="false" checked>
-            <span class="ed-optopt__emoji">📖</span>
+            <span class="ed-optopt__emoji">😴</span>
             <span class="ed-optopt__name">Not right now</span>
             <span class="ed-optopt__desc">Just browse the site</span>
           </label>
           <label class="ed-optopt">
             <input type="radio" name="subscribed" value="true">
-            <span class="ed-optopt__emoji">✉️</span>
+            <span class="ed-optopt__emoji">📬</span>
             <span class="ed-optopt__name">Email me daily</span>
-            <span class="ed-optopt__desc">A prompt each morning</span>
+            <span class="ed-optopt__desc">A prompt each day</span>
           </label>
         </div>
         <p class="ed-hint">You can change this any time in settings.</p>

--- a/core/templates/core/settings.html
+++ b/core/templates/core/settings.html
@@ -37,42 +37,6 @@
   {% endif %}
 
   <section class="ed-card">
-    <h2 class="ed-card__head">Subscription &amp; timezone</h2>
-    <p class="ed-card__sub">Control whether you get a daily prompt and when it arrives.</p>
-    <form method="post" action="">
-      {% csrf_token %}
-      <div class="ed-field">
-        <label class="ed-check">
-          <input type="checkbox" name="subscribed"{% if user.is_subscribed %} checked{% endif %}>
-          <span>Subscribed &mdash; receive a writing prompt by email every day.</span>
-        </label>
-      </div>
-      <div class="ed-field">
-        <label class="ed-field__label" for="id_timezone">Time zone</label>
-        {% load tz %}
-        {% with user.timezone as user_tz %}
-        <select class="ed-input" name="timezone" id="id_timezone">
-          {% for tz in timezones %}
-          <option value="{{ tz }}"{% if tz == user_tz %} selected{% endif %}>{{ tz }}</option>
-          {% endfor %}
-        </select>
-        {% endwith %}
-        <p class="ed-hint">Your daily prompt is sent in this time zone.</p>
-      </div>
-      <div class="ed-field">
-        <label class="ed-field__label" for="id_mail_hour">Delivery time</label>
-        <select class="ed-input" name="mail_hour" id="id_mail_hour">
-          {% for h in hours %}
-          <option value="{{ h.0 }}"{% if h.0 == user.mail_hour %} selected{% endif %}>{{ h.1 }}</option>
-          {% endfor %}
-        </select>
-        <p class="ed-hint">When your daily prompt arrives, in the time zone above.</p>
-      </div>
-      <button class="ed-btn" type="submit">Update settings</button>
-    </form>
-  </section>
-
-  <section class="ed-card">
     <h2 class="ed-card__head">Account</h2>
     <p class="ed-card__sub">Manage access to your account.</p>
 
@@ -128,6 +92,53 @@
     <div class="ed-alert ed-alert--ok">Password reset link sent to {{ user.email }}.</div>
     {% endif %}
     <p class="ed-hint">Reset password sends a link to {{ user.email }}.</p>
+  </section>
+
+  <section class="ed-card">
+    <h2 class="ed-card__head">Subscription &amp; timezone</h2>
+    <p class="ed-card__sub">Control whether you get a daily prompt and when it arrives.</p>
+    <form method="post" action="">
+      {% csrf_token %}
+      <div class="ed-field">
+        <span class="ed-field__label">Daily email</span>
+        <div class="ed-optgroup">
+          <label class="ed-optopt">
+            <input type="radio" name="subscribed" value="false"{% if not user.is_subscribed %} checked{% endif %}>
+            <span class="ed-optopt__emoji">😴</span>
+            <span class="ed-optopt__name">Not right now</span>
+            <span class="ed-optopt__desc">Just browse the site</span>
+          </label>
+          <label class="ed-optopt">
+            <input type="radio" name="subscribed" value="true"{% if user.is_subscribed %} checked{% endif %}>
+            <span class="ed-optopt__emoji">📬</span>
+            <span class="ed-optopt__name">Email me daily</span>
+            <span class="ed-optopt__desc">A prompt each day</span>
+          </label>
+        </div>
+      </div>
+      <div class="ed-field">
+        <label class="ed-field__label" for="id_timezone">Time zone</label>
+        {% load tz %}
+        {% with user.timezone as user_tz %}
+        <select class="ed-input" name="timezone" id="id_timezone">
+          {% for tz in timezones %}
+          <option value="{{ tz }}"{% if tz == user_tz %} selected{% endif %}>{{ tz }}</option>
+          {% endfor %}
+        </select>
+        {% endwith %}
+        <p class="ed-hint">Your daily prompt is sent in this time zone.</p>
+      </div>
+      <div class="ed-field">
+        <label class="ed-field__label" for="id_mail_hour">Delivery time</label>
+        <select class="ed-input" name="mail_hour" id="id_mail_hour">
+          {% for h in hours %}
+          <option value="{{ h.0 }}"{% if h.0 == user.mail_hour %} selected{% endif %}>{{ h.1 }}</option>
+          {% endfor %}
+        </select>
+        <p class="ed-hint">When your daily prompt arrives, in the time zone above.</p>
+      </div>
+      <button class="ed-btn" type="submit">Save settings</button>
+    </form>
   </section>
 </div>
 {% endblock %}

--- a/dailyinquirer/static/css/account.css
+++ b/dailyinquirer/static/css/account.css
@@ -213,14 +213,14 @@
   margin: 4px 0 16px;
 }
 
-/* --- Onboarding: daily-email opt-in choice cards ------------ */
+/* --- Daily-email opt-in choice cards (onboarding + settings) - */
 
-#onboarding .ed-optgroup {
+.ed-optgroup {
   display: flex;
   gap: 8px;
 }
 
-#onboarding .ed-optopt {
+.ed-optopt {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -235,40 +235,40 @@
   transition: border-color 0.15s ease, background 0.15s ease;
 }
 
-#onboarding .ed-optopt:hover {
+.ed-optopt:hover {
   border-color: var(--accent);
 }
 
-#onboarding .ed-optopt:has(input:focus-visible) {
+.ed-optopt:has(input:focus-visible) {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
-#onboarding .ed-optopt:has(input:checked) {
+.ed-optopt:has(input:checked) {
   border-color: var(--accent);
   background: rgba(var(--accent-rgb), 0.06);
   box-shadow: inset 0 0 0 1px var(--accent);
 }
 
-#onboarding .ed-optopt input {
+.ed-optopt input {
   position: absolute;
   opacity: 0;
   pointer-events: none;
 }
 
-#onboarding .ed-optopt__emoji {
+.ed-optopt__emoji {
   font-size: 1.5rem;
   line-height: 1;
 }
 
-#onboarding .ed-optopt__name {
+.ed-optopt__name {
   font-family: var(--body);
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--ink);
 }
 
-#onboarding .ed-optopt__desc {
+.ed-optopt__desc {
   font-family: var(--body);
   font-size: 0.875rem;
   color: var(--ink-faint);


### PR DESCRIPTION
## Summary
- Replace the settings page subscribe checkbox with the onboarding-style squared choice cards (😴 Not right now / 📬 Email me daily)
- Move the **Account** section above **Subscription & timezone** on the settings page
- Unscope the choice-card CSS from `#onboarding` so it applies on both the onboarding and settings pages
- Reword "A prompt each morning" → "A prompt each day" and the settings submit button "Update settings" → "Save settings"

## Test plan
- `python manage.py test` — all 180 tests pass
- The radios submit `value="false"`/`value="true"`, which Django's `BooleanField(required=False)` parses to `False`/`True` — same handling the onboarding form already relies on

🤖 Generated with [Claude Code](https://claude.com/claude-code)